### PR TITLE
README: Update installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,11 +81,19 @@ Help Options:
   HTTPS ([draft-pauly-dprive-oblivious-doh-11](https://tools.ietf.org/html/draft-pauly-dprive-oblivious-doh-11))
 
 ### Installation
+`q` is available in binary form from:  
+* [my public package repositories](https://github.com/natesales/repo),
+* [GitHub releases](https://github.com/natesales/q/releases),
+* and the AUR as [q-dns-git](https://aur.archlinux.org/packages/q-dns-git/)
 
-`q` is available from my [public package repositories](https://github.com/natesales/repo), as a binary
-from [releases](https://github.com/natesales/q/releases), from the AUR
-as [q-dns-git](https://aur.archlinux.org/packages/q-dns-git/), or from source
-with `git clone https://github.com/natesales/q && cd q && go build`.
+To install `q` from source do:  
+```sh
+git clone https://github.com/natesales/q && cd q
+go install
+
+# without debug information
+go install -ldflags="-s -w -X main.version=release"
+```
 
 ### Feature Comparison
 


### PR DESCRIPTION
Update the installation section in the README and tell the user how to produce a non-debug version from source.
Useful since q doesn't seem to use go tags but rather GoReleaser, which is third-party (currently the user has to figure out how to produce a release version with/without GoReleaser).