### PR TITLE
fix(resolver): Generate message ID for DNS query

### DIFF
--- a/resolver.go
+++ b/resolver.go
@@ -24,6 +24,7 @@ func createQuery(
 	for _, qType := range rrTypes {
 		req := dns.Msg{}
 
+		req.Id = dns.Id()
 		req.Authoritative = aaFlag
 		req.AuthenticatedData = adFlag
 		req.CheckingDisabled = cdFlag


### PR DESCRIPTION
Zero ID is undefined in spec, some DNS servers might treat this as a malformed query.

For example in my WSL:
```
q google.com A
```
The local DNS server will receive the following request with ID 0:
```
tcpdump: verbose output suppressed, use -v[v]... for full protocol decode
listening on eth0, link-type EN10MB (Ethernet), snapshot length 262144 bytes
16:06:31.693003 IP 172.30.70.197.48108 > ..domain: 0+ A? google.com. (28)
16:06:31.698901 IP ..domain > 172.30.70.197.48108: 62696- 1/0/0 A 172.217.163.46 (54)
```
The request will return a timeout error
```
FATA[0010] read udp 172.30.70.197:48108->172.30.64.1:53: i/o timeout
```

And `dig` will correctly generate a random ID 45960 and get the response. 
```
q google.com A
```
```
tcpdump: verbose output suppressed, use -v[v]... for full protocol decode
listening on eth0, link-type EN10MB (Ethernet), snapshot length 262144 bytes
16:11:39.973448 IP 172.30.70.197.33234 > ..domain: 45960+ [1au] A? google.com. (51)
16:11:39.973898 IP ..domain > 172.30.70.197.33234: 45960-$ 1/0/0 A 142.251.43.14 (54)
```

Here is the related issue:
https://github.com/microsoft/WSL/issues/7964