### PR TITLE
Close the QUIC connection to avoid retransmissions and icmp unreachable

### DIFF
--- a/transport/quic.go
+++ b/transport/quic.go
@@ -68,6 +68,10 @@ func (q *QUIC) Exchange(msg *dns.Msg) (*dns.Msg, error) {
 		if err != nil {
 			return nil, fmt.Errorf("opening quic session to %s: %v", q.Server, err)
 		}
+
+		// close quic connection on to avoid retransmission.
+		defer q.Close()
+
 		q.conn = &conn
 	}
 


### PR DESCRIPTION
This PR fixes #47.

Retransmissions are sent by the remote server to the client, it's why we have ICMP unreachable.

with the fix

![image](https://github.com/natesales/q/assets/5562930/315e2fe6-f3eb-4f3d-8c55-12e1651bd62c)

without the fix

![image](https://github.com/natesales/q/assets/5562930/aaa5c8c8-243e-4afd-abdb-ef4a7f158dd6)
