### PR TITLE
Fix IPv6 link local address without brackets

### DIFF
--- a/main.go
+++ b/main.go
@@ -119,7 +119,7 @@ func setPort(u *url.URL, port int) {
 func parseServer(s string) (string, transport.Type, error) {
 	// Remove IPv6 scope ID if present
 	var scopeId string
-	v6scopeRe := regexp.MustCompile(`\[[a-fA-F0-9:]+%[a-zA-Z0-9]+]`)
+	v6scopeRe := regexp.MustCompile(`(^|\[)[a-fA-F0-9:]+%[a-zA-Z0-9]+`)
 	if v6scopeRe.MatchString(s) {
 		v6scopeRemoveRe := regexp.MustCompile(`(%[a-zA-Z0-9]+)`)
 		matches := v6scopeRemoveRe.FindStringSubmatch(s)

--- a/main_test.go
+++ b/main_test.go
@@ -442,6 +442,11 @@ func TestMainParseServer(t *testing.T) {
 			Type:         transport.TypeQUIC,
 			ExpectedHost: "dns.adguard.com:8530",
 		},
+		{ // IPv6 plain with scope ID but without port
+			Server:       "fe80::1%en0",
+			Type:         transport.TypePlain,
+			ExpectedHost: "[fe80::1%en0]:53",
+		},
 		{ // IPv6 with scope ID and explicit port
 			Server:       "plain://[fe80::1%en0]:53",
 			Type:         transport.TypePlain,


### PR DESCRIPTION
If the macos use the  link local address as nameserver, it does not contain [].