### PR TITLE
fix: add url path from dnsstamp

### DIFF
--- a/main.go
+++ b/main.go
@@ -98,6 +98,7 @@ func dnsStampToURL(s string) (string, error) {
 
 	// TODO: This might be a source of problems...we might want to be using parsedStamp.ServerAddrStr
 	u.Host = parsedStamp.ProviderName
+	u.Path = parsedStamp.Path
 
 	log.Tracef("DNS stamp parsed into URL as %s", u.String())
 	return u.String(), nil

--- a/main_test.go
+++ b/main_test.go
@@ -543,3 +543,24 @@ func TestMainQueryTypeFlag(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Regexp(t, regexp.MustCompile(`cloudflare.com. .* HTTPS 1 .*`), out.String())
 }
+
+func TestMainDnsstampDoH(t *testing.T) {
+	out, err := run(
+		"@sdns://AgcAAAAAAAAADjEwNC4xNi4yNDguMjQ5ABJjbG91ZGZsYXJlLWRucy5jb20A", // cloudflare-dns.com
+		"--all",
+	)
+
+	assert.Nil(t, err)
+	assert.Contains(t, out.String(), "from https://cloudflare-dns.com:443/dns-query")
+}
+
+func TestMainDnsstampDoHPath(t *testing.T) {
+	_, err := run(
+		"@sdns://AgcAAAAAAAAADjEwNC4xNi4yNDguMjQ5ABJjbG91ZGZsYXJlLWRucy5jb20FL3Rlc3Q", // cloudflare-dns.com/test
+		"--all",
+	)
+
+	// use err here because the query will result in a 404
+	assert.Contains(t, err.Error(), "from https://cloudflare-dns.com:443/test")
+}
+

--- a/main_test.go
+++ b/main_test.go
@@ -564,3 +564,13 @@ func TestMainDnsstampDoHPath(t *testing.T) {
 	assert.Contains(t, err.Error(), "from https://cloudflare-dns.com:443/test")
 }
 
+func TestMainDnsstampInvalid(t *testing.T) {
+	_, err := run(
+		"@sdns://invalid",
+		"--all",
+	)
+
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "converting DNS stamp to URL: illegal base64 data")
+}
+


### PR DESCRIPTION
With this fix, the path from a Dnsstamp is applied correctly.
Previously, the default ‘/dns-query’ was used regardless of the setting of the Dnsstamp.