### PR TITLE
Add DOH header support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ q example.com MX SOA                     ...or specify a list of types
 q example.com MX @9.9.9.9                Query a specific server
 q example.com MX @https://dns.quad9.net  ...over HTTPS (or TCP, TLS, QUIC, or ODoH)...
 q @sdns://AgcAAAAAAAAAAAAHOS45LjkuOQA    ...or from a DNS Stamp
+q example.com --header='X-Client-ID: abc' Add custom headers to DOH requests
 
 q example.com MX --format=raw            Output in raw (dig) format
 q example.com MX --format=json           ...or as JSON (or YAML)
@@ -99,6 +100,7 @@ Application Options:
       --tls-key-log-file=         TLS key log file [$SSLKEYLOGFILE]
       --http-user-agent=          HTTP user agent
       --http-method=              HTTP method (default: GET)
+      --header=                   HTTP header in format 'Name: Value'
       --pmtud                     PMTU discovery (default: true)
       --quic-alpn-tokens=         QUIC ALPN tokens (default: doq, doq-i11)
       --quic-length-prefix        Add RFC 9250 compliant length prefix
@@ -202,6 +204,7 @@ the `SSLKEYLOGFILE` environment variable is set to a file path.
 | TC                            | ✅ |   ❌   |  ❌  |  ✅   |  ✅  |   ✅   |
 | **Protocol Tweaks**           |   |       |     |      |     |       |
 | HTTP Method                   | ✅ |   ❌   |  ❌  |  ❌   |  ❌  |   ❌   |
+| HTTP Headers                  | ✅ |   ❌   |  ❌  |  ❌   |  ❌  |   ❌   |
 | QUIC ALPN Tokens              | ✅ |   ❌   |  ❌  |  ❌   |  ❌  |   ❌   |
 | QUIC toggle PMTU discovery    | ✅ |   ❌   |  ❌  |  ❌   |  ❌  |   ❌   |
 | QUIC timeouts (dial and idle) | ✅ |   ❌   |  ❌  |  ❌   |  ❌  |   ❌   |

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -77,8 +77,9 @@ type Flags struct {
 	TLSKeyLogFile         string   `long:"tls-key-log-file" env:"SSLKEYLOGFILE" description:"TLS key log file"`
 
 	// HTTP
-	HTTPUserAgent string `long:"http-user-agent" description:"HTTP user agent" default:""`
-	HTTPMethod    string `long:"http-method" description:"HTTP method" default:"GET"`
+	HTTPUserAgent string   `long:"http-user-agent" description:"HTTP user agent" default:""`
+	HTTPMethod    string   `long:"http-method" description:"HTTP method" default:"GET"`
+	HTTPHeaders   []string `long:"header" description:"HTTP header in format 'Name: Value'"`
 
 	PMTUD bool `long:"pmtud" description:"PMTU discovery (default: true)"`
 

--- a/resolver.go
+++ b/resolver.go
@@ -135,6 +135,21 @@ func newTransport(server string, transportType transport.Type, tlsConfig *tls.Co
 			}
 		} else {
 			log.Debugf("Using HTTP(s) transport: %s", server)
+
+			// Parse HTTP headers
+			headers := make(map[string]string)
+			for _, header := range opts.HTTPHeaders {
+				parts := strings.SplitN(header, ":", 2)
+				if len(parts) == 2 {
+					name := strings.TrimSpace(parts[0])
+					value := strings.TrimSpace(parts[1])
+					headers[name] = value
+					log.Debugf("Added header %s: %s", name, value)
+				} else {
+					log.Warnf("Invalid header format: %s (expected 'Name: Value')", header)
+				}
+			}
+
 			ts = &transport.HTTP{
 				Common:    common,
 				TLSConfig: tlsConfig,
@@ -143,6 +158,7 @@ func newTransport(server string, transportType transport.Type, tlsConfig *tls.Co
 				HTTP2:     opts.HTTP2,
 				HTTP3:     opts.HTTP3,
 				NoPMTUd:   !opts.PMTUD,
+				Headers:   headers,
 			}
 		}
 	case transport.TypeDNSCrypt:

--- a/transport/http.go
+++ b/transport/http.go
@@ -23,6 +23,7 @@ type HTTP struct {
 	Method       string
 	HTTP2, HTTP3 bool
 	NoPMTUd      bool
+	Headers      map[string]string
 
 	conn *http.Client
 }
@@ -81,6 +82,14 @@ func (h *HTTP) Exchange(m *dns.Msg) (*dns.Msg, error) {
 	if h.UserAgent != "" {
 		log.Debugf("Setting User-Agent to %s", h.UserAgent)
 		req.Header.Set("User-Agent", h.UserAgent)
+	}
+
+	// Set custom headers if provided
+	if h.Headers != nil {
+		for name, value := range h.Headers {
+			log.Debugf("Setting custom header %s: %s", name, value)
+			req.Header.Set(name, value)
+		}
 	}
 
 	log.Debugf("[http] sending %s request to %s", h.Method, queryURL)


### PR DESCRIPTION
Adds the ability to attach HTTP headers to DOH queries. Useful for some DNS providers (Control D, NextDNS) that pass additional metadata via headers. 

Example usage:

```
./q @https://dns.controld.com/xxxxxxx test.com --header="X-Cd-Host:test" --header="X-Cd-Mac:a:b:c:d:e:f" --header="X-Cd-IP:192.168.1.69"
```