### PR TITLE
Show the Authority and Additional parts for NS query

### DIFF
--- a/main.go
+++ b/main.go
@@ -284,6 +284,10 @@ All long form (--) flags can be toggled with the dig-standard +[no]flag notation
 		rrType, typeFound := dns.StringToType[strings.ToUpper(arg)]
 		if typeFound {
 			rrTypes[rrType] = true
+			if rrType == dns.TypeNS {
+				opts.ShowAuthority = true
+				opts.ShowAdditional = true
+			}
 		}
 
 		// Set qname if not set by flag


### PR DESCRIPTION
The response of NS type query is located in the authority and additional part, enable show them by default.

Run the following query show nothing now:

```bash
q ns zz.ac @a0.nic.ac
```

However, the expected output should be (which is equal to `q ns zz.ac @a0.nic.ac --additional --authority`):

```bash
Authority:
zz.ac. 1h NS ns1.zz.ac.
zz.ac. 1h NS ns2.zz.ac.
zz.ac. 1h NS ns3.zz.ac.
Additional:
ns1.zz.ac. 1h A 122.9.71.163
ns2.zz.ac. 1h A 154.21.82.127
ns3.zz.ac. 1h A 77.90.40.193
ns1.zz.ac. 1h AAAA 2407:c080:801:fffe::7a09:47a3
ns2.zz.ac. 1h AAAA 2605:52c0:2:11b2::
ns3.zz.ac. 1h AAAA 2a0f:85c1:b73:c7::a
```