### PR TITLE
fix: QUIC transport ignoring --quic-alpn-tokens in favor of --tls-next-protos

### DIFF
--- a/resolver.go
+++ b/resolver.go
@@ -185,7 +185,7 @@ func newTransport(server string, transportType transport.Type, tlsConfig *tls.Co
 		log.Debugf("Using QUIC transport: %s", server)
 
 		tc := tlsConfig.Clone()
-		tlsConfig.NextProtos = opts.QUICALPNTokens
+		tc.NextProtos = opts.QUICALPNTokens
 
 		ts = &transport.QUIC{
 			Common:          common,


### PR DESCRIPTION


## Bug Fix: DoQ transport ignores `--quic-alpn-tokens` in favor of `--tls-next-protos`

### Summary

When performing a DNS-over-QUIC query, the application incorrectly uses the value from the general-purpose `--tls-next-protos` flag for ALPN, ignoring the more specific `--quic-alpn-tokens`. This results in incorrect ALPN negotiation for DoQ when both flags are present. 

### Problem

If both `--quic-alpn-tokens` and `--tls-next-protos` are specified, the ALPN used in the QUIC Client Hello is taken from `--tls-next-protos`, breaking compatibility with DoQ servers expecting a specific ALPN.

### Root Cause

In `resolver.go`, `tlsConfig.Clone()` is called, but `NextProtos` is mistakenly set on the original `tlsConfig` instead of the cloned `tc`. The QUIC transport ends up using the unmodified clone:

```go
tc := tlsConfig.Clone()
tlsConfig.NextProtos = opts.QUICALPNTokens // Bug: modifies original, not clone
```

### Fix

Set `NextProtos` on the cloned `tc` before passing it to the QUIC transport:

```go
tc := tlsConfig.Clone()
tc.NextProtos = opts.QUICALPNTokens // Fixed: modifies the clone correctly
```

### Reproduction

```bash
q @quic://1.2.3.4:853 --quic-alpn-tokens="this-is-quic-alpn-tokens" --tls-next-protos="this-is-tls-next-protos" example.com A 
```

### Evidence

Wireshark capture shows the Client Hello uses the value from `--tls-next-protos`, not `--quic-alpn-tokens`:

<img width="998" height="726" alt="ALPN evidence" src="https://github.com/user-attachments/assets/c622d138-f1c2-4e4f-a228-4033d9e0b859" />
