### PR TITLE
Fix timeout handling in Plain transport

### DIFF
--- a/resolver.go
+++ b/resolver.go
@@ -205,6 +205,7 @@ func newTransport(server string, transportType transport.Type, tlsConfig *tls.Co
 			Common:    common,
 			PreferTCP: true,
 			UDPBuffer: opts.UDPBuffer,
+			Timeout:   opts.Timeout,
 		}
 	case transport.TypePlain:
 		log.Debugf("Using UDP with TCP fallback: %s", server)
@@ -212,6 +213,7 @@ func newTransport(server string, transportType transport.Type, tlsConfig *tls.Co
 			Common:    common,
 			PreferTCP: false,
 			UDPBuffer: opts.UDPBuffer,
+			Timeout:   opts.Timeout,
 		}
 	default:
 		return nil, fmt.Errorf("unknown transport protocol %s", transportType)

--- a/transport/plain.go
+++ b/transport/plain.go
@@ -1,6 +1,8 @@
 package transport
 
 import (
+	"time"
+
 	"github.com/miekg/dns"
 	log "github.com/sirupsen/logrus"
 )
@@ -10,16 +12,17 @@ type Plain struct {
 	Common
 	PreferTCP bool
 	UDPBuffer uint16
+	Timeout   time.Duration
 }
 
 func (p *Plain) Exchange(m *dns.Msg) (*dns.Msg, error) {
-	tcpClient := dns.Client{Net: "tcp"}
+	tcpClient := dns.Client{Net: "tcp", Timeout: p.Timeout}
 	if p.PreferTCP {
 		reply, _, tcpErr := tcpClient.Exchange(m, p.Server)
 		return reply, tcpErr
 	}
 
-	client := dns.Client{UDPSize: p.UDPBuffer}
+	client := dns.Client{UDPSize: p.UDPBuffer, Timeout: p.Timeout}
 	reply, _, err := client.Exchange(m, p.Server)
 
 	if reply != nil && reply.Truncated {

--- a/transport/plain_test.go
+++ b/transport/plain_test.go
@@ -14,6 +14,7 @@ func plainTransport() *Plain {
 		},
 		PreferTCP: false,
 		UDPBuffer: 1232,
+		Timeout: 0,
 	}
 }
 


### PR DESCRIPTION
Timeout value was never actually passed from the CLI options to the Transport.

Current: i/o timeout after 2s
```
time q @1.1.1.1 @1.0.0.1 PTR 253.175.167.220.in-addr.arpa --timeout=5s 
FATA[0002] exchange: read udp 10.2.0.2:64054->1.1.1.1:53: i/o timeout 
q @1.1.1.1 @1.0.0.1 PTR 253.175.167.220.in-addr.arpa --timeout=5s  0.01s user 0.01s system 0% cpu 2.039 total
```
Time: 2.039 total


Fixed: planned 5s timeout
```
time ./q @1.1.1.1 @1.0.0.1 PTR 253.175.167.220.in-addr.arpa --timeout=5s
FATA[0005] timeout after 5s                             
./q @1.1.1.1 @1.0.0.1 PTR 253.175.167.220.in-addr.arpa --timeout=5s  0.01s user 0.02s system 0% cpu 5.054 total                           
```
time:  5.054 total