### PR TITLE
feat: Support multiple HTTP headers with the same name

### DIFF
--- a/resolver.go
+++ b/resolver.go
@@ -137,13 +137,13 @@ func newTransport(server string, transportType transport.Type, tlsConfig *tls.Co
 			log.Debugf("Using HTTP(s) transport: %s", server)
 
 			// Parse HTTP headers
-			headers := make(map[string]string)
+			headers := make(map[string][]string)
 			for _, header := range opts.HTTPHeaders {
 				parts := strings.SplitN(header, ":", 2)
 				if len(parts) == 2 {
 					name := strings.TrimSpace(parts[0])
 					value := strings.TrimSpace(parts[1])
-					headers[name] = value
+					headers[name] = append(headers[name], value)
 					log.Debugf("Added header %s: %s", name, value)
 				} else {
 					log.Warnf("Invalid header format: %s (expected 'Name: Value')", header)

--- a/transport/http.go
+++ b/transport/http.go
@@ -23,7 +23,7 @@ type HTTP struct {
 	Method       string
 	HTTP2, HTTP3 bool
 	NoPMTUd      bool
-	Headers      map[string]string
+	Headers      map[string][]string
 
 	conn *http.Client
 }
@@ -85,9 +85,11 @@ func (h *HTTP) Exchange(m *dns.Msg) (*dns.Msg, error) {
 
 	// Set custom headers if provided
 	if h.Headers != nil {
-		for name, value := range h.Headers {
-			log.Debugf("Setting custom header %s: %s", name, value)
-			req.Header.Set(name, value)
+		for name, values := range h.Headers {
+			for _, value := range values {
+				log.Debugf("Setting custom header %s: %s", name, value) 
+				req.Header.Add(name, value)
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR adds support for specifying multiple HTTP headers with the same name for DoH queries, which is a standard feature of HTTP.

**Problem:**
Currently, if a user provides multiple `--http-header` flags with the same name (e.g., for cookies or other custom use cases), only the last one is used. This is because the headers are stored in a `map[string]string`, which overwrites previous values for the same key.

**Solution:**
I've made the following changes:
1.  Modified `resolver.go` to parse headers into a `map[string][]string`.
2.  Updated the `transport.HTTP` struct in `transport/http.go` to accept `map[string][]string`.
3.  Changed the request logic in `transport/http.go` to loop through all values for a given header name and use `req.Header.Add()` instead of `req.Header.Set()`.

---

### **Verification**

I have verified the fix using `tshark` to inspect the raw network traffic.

**1. Start `tshark` to capture traffic:**
```bash
tshark -i 4 -f "host 101.102.103.104" -o tls.keylog_file:"C:\temp\sslkeys.log" -Y http2 -V
```
2. Run the modified q with duplicate custom headers:
```bash
set SSLKEYLOGFILE=C:\temp\sslkeys.log
q.exe -s https://101.102.103.104/dns-query -t A google.com --http2 -i --http-header "X-Test: value1" --http-header "X-Test: value2"
```
3. tshark Output Confirmation: The captured HEADERS frame clearly shows that two separate X-Test headers were sent, confirming the fix is working correctly at the protocol level.
```
        Header: x-test: value1
            Name Length: 6
            Name: x-test
            Value Length: 6
            Value: value1
            [Unescaped: value1]
            Representation: Literal Header Field with Incremental Indexing - New Name
        Header: x-test: value2
            Name Length: 6
            Name: x-test
            Value Length: 6
            Value: value2
            [Unescaped: value2]
            Representation: Literal Header Field with Incremental Indexing - Indexed Name
            Index: 62
```