### PR TITLE
Instructions for Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Help Options:
 `q` is available from:
 
 - [apt/yum/brew from my package repositories](https://github.com/natesales/repo)
+- [Homebrew core repository](https://formulae.brew.sh/formula/q)
 - [GitHub releases](https://github.com/natesales/q/releases)
 - [q-dns-git](https://aur.archlinux.org/packages/q-dns-git/) in the AUR
 - `go install github.com/natesales/q@latest`


### PR DESCRIPTION
Q is now [available](https://github.com/Homebrew/homebrew-core/commit/2619c5937d08bf1fe24a8450cdde1bb2a959227f) via the official Core repository.