### PR TITLE
fix: allow underscores during IDNA conversion

### DIFF
--- a/main.go
+++ b/main.go
@@ -326,11 +326,13 @@ All long form (--) flags can be toggled with the dig-standard +[no]flag notation
 		// Skip if already an in-addr.arpa or ip6.arpa name
 		lowerName := strings.ToLower(opts.Name)
 		if !strings.HasSuffix(lowerName, ".in-addr.arpa") && !strings.HasSuffix(lowerName, ".ip6.arpa") {
-			asciiName, err := idna.Lookup.ToASCII(opts.Name)
+			// Allow underscores during IDNA conversion
+			_asciiName := strings.ReplaceAll(opts.Name, "_", "x")
+			asciiName, err := idna.Lookup.ToASCII(_asciiName)
 			if err != nil {
 				return fmt.Errorf("idna toascii: %s", err)
 			}
-			opts.Name = asciiName
+			opts.Name = strings.ReplaceAll(asciiName, "x", "_")
 		}
 	}
 


### PR DESCRIPTION
Domains may contain underscores, e.g., _acme-challenge.cloudflare.com. 
Previously, querying such domains (e.g., `q @8.8.8.8 _acme-challenge.cloudflare.com`) 
would fail with "idna toascii: idna: disallowed rune U+005F". 
This patch handles underscores to prevent IDNA conversion errors.