### PR TITLE
Add Windows zip format override in goreleaser config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,9 +17,9 @@ builds:
       - arm64
 
 archives:
-  format_overrides:
-    - goos: windows
-      formats: ["zip"]
+  - format_overrides:
+      - goos: windows
+        formats: ["zip"]
 
 changelog:
   sort: asc


### PR DESCRIPTION
Add format override for Windows archives to use zip format

Necessary for Winget packaging. See #139.

I am not able to test this without a setting up a whole host of things, sorry about that.





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set GoReleaser to produce .zip archives for Windows builds to meet Winget packaging requirements. No changes to other platforms.

<sup>Written for commit a8df6b83eaa8229811d516689df115fc3c5728b1. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





