### PR TITLE
fix: resolve issue with combining short flags and equal signs

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -152,7 +152,7 @@ func SetDefaultTrueBools(opts *Flags) {
 func SetFalseBooleans(opts *Flags, args []string) []string {
 	// Add equal signs to separated flags (e.g. --foo bar becomes --foo=bar)
 	for i, arg := range args {
-		if arg[0] == '-' && !strings.Contains(arg, "=") && i+1 < len(args) && (args[i+1] == "true" || args[i+1] == "false") {
+		if len(arg) > 0 && arg[0] == '-' && !strings.Contains(arg, "=") && i+1 < len(args) && (args[i+1] == "true" || args[i+1] == "false") {
 			args[i] = arg + "=" + args[i+1]
 			args = append(args[:i+1], args[i+2:]...)
 		}
@@ -253,12 +253,13 @@ func AddEqualSigns(args []string) []string {
 				if i+1 < len(args) {
 					nextArg := args[i+1]
 					// Skip if the next argument is a server specified with @
-					if nextArg[0] == '@' {
+					if len(nextArg) > 0 && nextArg[0] == '@' {
 						newArgs = append(newArgs, arg)
 						continue
 					}
+					
 					// If the next argument is a value (not a flag), combine them
-					if nextArg[0] != '-' {
+					if len(nextArg) == 0 || nextArg[0] != '-' {
 						newArgs = append(newArgs, arg+"="+nextArg)
 						skip = true
 					} else {


### PR DESCRIPTION
### Description

This PR fixes an issue where the argument pre-processor (`AddEqualSigns`) incorrectly treated combined short flags (e.g., `-rw`) as long flags, attempting to append an `=` sign and causing parsing errors (e.g., `unknown flag '='`).

### Changes

- Updated `cli.AddEqualSigns` to treat only `--`-prefixed arguments as long flags.
- Short flags and combined short flags are now passed through to the underlying `go-flags` parser unchanged.
- Added comments to clarify the logic.

### Verification

I have verified the fix with the following test cases on Windows:
```
D:\q>go run . -rw A g.co -s tls://1.1.1.1
142.250.176.14 (AS15169 Google LLC)

D:\q>go run . -rq g.co A -s tls://1.1.1.1
172.217.14.110

D:\q>go run . --server tls://1.1.1.1 A google.com
google.com. 2m33s A 142.251.34.78

D:\q>go run . --verbose google.com -s tls://1.1.1.1
DEBU Name: google.com
DEBU RR types: [AAAA NS MX TXT CNAME A]
DEBU Server(s): [tls://1.1.1.1]
DEBU Using server 1.1.1.1:853 with transport tls
DEBU Using TLS transport: 1.1.1.1:853
google.com. 41m1s TXT "MS=E4A68B9AB2BB9670BCE15412F62916164C0B20BB"
google.com. 41m1s TXT "apple-domain-verification=30afIBcvSuDV2PLX"
google.com. 41m1s TXT "cisco-ci-domain-verification=47c38bc8c4b74b7233e9053220c1bbe76bcc1cd33c7acf7acd36cd6a5332004b"
google.com. 41m1s TXT "docusign=05958488-4752-4ef2-95eb-aa7ba8a3bd0e"
google.com. 41m1s TXT "docusign=1b0a6754-49b1-4db5-8540-d2c12664b289"
google.com. 41m1s TXT "facebook-domain-verification=22rm551cu4k0ab0bxsw536tlds4h95"
google.com. 41m1s TXT "globalsign-smime-dv=CDYX+XFHUw2wml6/Gb8+59BsH31KzUr6c1l2BPvqKX8="
google.com. 41m1s TXT "google-site-verification=4ibFUgB-wXLQ_S7vsXVomSTVamuOXBiVAzpR5IZ87D0"
google.com. 41m1s TXT "google-site-verification=TV9-DBe4R80X4v0M4U_bd_J9cpOJM0nikft0jAgjmsQ"
google.com. 41m1s TXT "google-site-verification=wD8N7i1JTNTkezJ49swvWW48f8_9xveREV4oB-0Hf5o"
google.com. 41m1s TXT "onetrust-domain-verification=de01ed21f2fa4d8781cbc3ffb89cf4ef"
google.com. 41m1s TXT "v=spf1 include:_spf.google.com ~all"
google.com. 1m33s A 142.250.72.142
google.com. 4m6s AAAA 2607:f8b0:4007:815::200e
google.com. 92h53m8s NS ns1.google.com.
google.com. 92h53m8s NS ns2.google.com.
google.com. 92h53m8s NS ns3.google.com.
google.com. 92h53m8s NS ns4.google.com.
google.com. 3m2s MX 10 smtp.google.com.

D:\q>go run . google.com @tls://1.1.1.1
google.com. 8m28s TXT "MS=E4A68B9AB2BB9670BCE15412F62916164C0B20BB"
google.com. 8m28s TXT "apple-domain-verification=30afIBcvSuDV2PLX"
google.com. 8m28s TXT "cisco-ci-domain-verification=47c38bc8c4b74b7233e9053220c1bbe76bcc1cd33c7acf7acd36cd6a5332004b"
google.com. 8m28s TXT "docusign=05958488-4752-4ef2-95eb-aa7ba8a3bd0e"
google.com. 8m28s TXT "docusign=1b0a6754-49b1-4db5-8540-d2c12664b289"
google.com. 8m28s TXT "facebook-domain-verification=22rm551cu4k0ab0bxsw536tlds4h95"
google.com. 8m28s TXT "globalsign-smime-dv=CDYX+XFHUw2wml6/Gb8+59BsH31KzUr6c1l2BPvqKX8="
google.com. 8m28s TXT "google-site-verification=4ibFUgB-wXLQ_S7vsXVomSTVamuOXBiVAzpR5IZ87D0"
google.com. 8m28s TXT "google-site-verification=TV9-DBe4R80X4v0M4U_bd_J9cpOJM0nikft0jAgjmsQ"
google.com. 8m28s TXT "google-site-verification=wD8N7i1JTNTkezJ49swvWW48f8_9xveREV4oB-0Hf5o"
google.com. 8m28s TXT "onetrust-domain-verification=de01ed21f2fa4d8781cbc3ffb89cf4ef"
google.com. 8m28s TXT "v=spf1 include:_spf.google.com ~all"
google.com. 1m23s A 142.251.34.78
google.com. 3m45s AAAA 2607:f8b0:4007:809::200e
google.com. 92h11m34s NS ns1.google.com.
google.com. 92h11m34s NS ns2.google.com.
google.com. 92h11m34s NS ns3.google.com.
google.com. 92h11m34s NS ns4.google.com.
google.com. 3m19s MX 10 smtp.google.com.

D:\q>go run . -rw --server tls://1.1.1.1 --verbose google.com
DEBU Name: google.com
DEBU RR types: [AAAA NS MX TXT CNAME A]
DEBU Server(s): [tls://1.1.1.1]
DEBU Using server 1.1.1.1:853 with transport tls
DEBU Using TLS transport: 1.1.1.1:853
142.250.72.174 (AS15169 Google LLC)
2607:f8b0:4007:803::200e (AS15169 Google LLC)
ns2.google.com.
ns1.google.com.
ns4.google.com.
ns3.google.com.
10 smtp.google.com.
"docusign=05958488-4752-4ef2-95eb-aa7ba8a3bd0e"
"cisco-ci-domain-verification=47c38bc8c4b74b7233e9053220c1bbe76bcc1cd33c7acf7acd36cd6a5332004b"
"globalsign-smime-dv=CDYX+XFHUw2wml6/Gb8+59BsH31KzUr6c1l2BPvqKX8="
"docusign=1b0a6754-49b1-4db5-8540-d2c12664b289"
"onetrust-domain-verification=de01ed21f2fa4d8781cbc3ffb89cf4ef"
"google-site-verification=TV9-DBe4R80X4v0M4U_bd_J9cpOJM0nikft0jAgjmsQ"
"MS=E4A68B9AB2BB9670BCE15412F62916164C0B20BB"
"v=spf1 include:_spf.google.com ~all"
"google-site-verification=4ibFUgB-wXLQ_S7vsXVomSTVamuOXBiVAzpR5IZ87D0"
"facebook-domain-verification=22rm551cu4k0ab0bxsw536tlds4h95"
"google-site-verification=wD8N7i1JTNTkezJ49swvWW48f8_9xveREV4oB-0Hf5o"
"apple-domain-verification=30afIBcvSuDV2PLX"
```

### Related Issues

Fixes #143 



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CLI flag parsing by only adding values to --long flags and leaving short and combined short flags (e.g., -rw) unchanged. Also prevents a panic when an empty argument is processed in SetFalseBooleans.

- **Bug Fixes**
  - Update AddEqualSigns to process only --prefixed flags; boolean long flags remain standalone.
  - Skip args that already include "=", and don't join when the next arg starts with "@".
  - Guard SetFalseBooleans against empty args to avoid index panics.

<sup>Written for commit 77c0df2ca8a01e4c017e858ae42b553cea786cbb. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



