### PR TITLE
Prevent nil pointer in QUIC Close method

### DIFF
--- a/transport/quic.go
+++ b/transport/quic.go
@@ -150,5 +150,8 @@ func addPrefix(b []byte) (m []byte) {
 }
 
 func (q *QUIC) Close() error {
+	if q.conn == nil {
+		return nil
+	}
 	return q.connection().CloseWithError(DoQNoError, "")
 }


### PR DESCRIPTION
Added a nil check for q.conn in the QUIC Close method to avoid potential nil pointer dereference errors when closing a QUIC connection.

Fixes the panic caused by attempting to close a connection when QUIC connection establishment fails: runtime error: invalid memory address or nil pointer dereference.

Test: Manual

```shell
q @quic://dns.google www.google.com
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented a panic in QUIC Close by making it a no-op when the connection was never established. This makes Close safe to call after failed QUIC setup.

- **Bug Fixes**
  - Guard q.conn in Close(); return nil if it's nil, otherwise call CloseWithError.

<sup>Written for commit 7d1cba99c5a483a5c2210455a13f5b7150ce6568. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

