### PR TITLE
fix: prevent panic on nil QUIC connection close

### DIFF
--- a/transport/quic.go
+++ b/transport/quic.go
@@ -150,5 +150,9 @@ func addPrefix(b []byte) (m []byte) {
 }
 
 func (q *QUIC) Close() error {
-	return q.connection().CloseWithError(DoQNoError, "")
+	if q.connection() == nil {
+		return nil
+	}
+
+    return q.connection().CloseWithError(DoQNoError, "")
 }


### PR DESCRIPTION
### Description

This PR fixes a runtime panic that occurs when the QUIC transport fails to establish a connection (e.g., timeout, connection refused, or blocked network).

When `quic.DialAddr` returns an error in `Exchange`, the `q.conn` remains `nil`. However, the cleanup logic subsequently calls `Close()`, which attempts to dereference the nil connection object (`q.connection().CloseWithError`), resulting in a segmentation violation.

### Changes

Added a check in `transport/quic.go` to verify if the connection is `nil` before attempting to close it.

### Verification

Before fix:
```console
K:\q>.\q.exe example.com @quic://127.0.0.1:54321
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x0 addr=0x0 pc=0x7ff7e05a761f]

goroutine 8 [running]:
github.com/quic-go/quic-go.(*Conn).setCloseError(...)
        C:/Users/Administrator/go/pkg/mod/github.com/quic-go/quic-go@v0.54.0/connection.go:1794
github.com/quic-go/quic-go.(*Conn).closeLocal(0x0, {0x7ff7e08bf940, 0xc0002840a0})
        C:/Users/Administrator/go/pkg/mod/github.com/quic-go/quic-go@v0.54.0/connection.go:1803 +0x5f
github.com/quic-go/quic-go.(*Conn).CloseWithError(0x0, 0x0, {0x0, 0x0})
        C:/Users/Administrator/go/pkg/mod/github.com/quic-go/quic-go@v0.54.0/connection.go:1819 +0x79
github.com/natesales/q/transport.(*QUIC).Close(0x7ff7e0801bff?)
        K:/q/transport/quic.go:153 +0x1d
main.driver.func2()
        K:/q/main.go:521 +0x590
created by main.driver in goroutine 1
        K:/q/main.go:447 +0x19c5
```

After fix:
```console
K:\q>.\q.exe example.com @quic://127.0.0.1:54321
FATA exchange: opening quic session to 127.0.0.1:54321: timeout: no recent network activity
```

### Related Issues

Fixes #150 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix panic when QUIC dial fails by not closing a nil connection. QUIC.Close() now checks for a nil conn and returns early, preventing a nil-pointer dereference during cleanup.

<sup>Written for commit 560e15fe3c5fb2777ee3473627d7ec39ac684527. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

