### PR TITLE
docs: Link docker usage to associated GHCR page

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Help Options:
 - [GitHub releases](https://github.com/natesales/q/releases)
 - [q-dns-git](https://aur.archlinux.org/packages/q-dns-git/) in the AUR
 - `go install github.com/natesales/q@latest`
-- `docker run --rm -it ghcr.io/natesales/q`
+- [`docker run --rm -it ghcr.io/natesales/q`](https://github.com/natesales/q/pkgs/container/q)
 
 To install `q` from source:
 


### PR DESCRIPTION
Since https://github.com/natesales/q/issues/152 has had no maintainer action yet, at least this minor change partially improves the UX for readers to discover/reach the GHCR page.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Docker run example in README link to the GHCR package page for `ghcr.io/natesales/q`, improving discoverability of the image and tags.

<sup>Written for commit ec52792b19e46b43b92d61028243392260af2ef4. Summary will update on new commits. <a href="https://cubic.dev/pr/natesales/q/pull/164?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

